### PR TITLE
Fix build for non-gcc compilers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     cc::Build::new()
         .file("stb/stb.c")
-        .flag("-Wno-unused-parameter")
-        .compile("stb")
+        .flag_if_supported("-Wno-unused-parameter")
+        .compile("stb");
 }


### PR DESCRIPTION
-Wno-unused-parameter is not supported on some compilers