### PR TITLE
Set custom OpenImageIO location

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ smol = "1"
 default = ["oiio", "parallel", "text"]
 window = ["gl", "glutin"]
 oiio = ["cpp", "cpp_build"]
+oiio-custom = ["cpp", "cpp_build"]
 parallel = ["rayon"]
 halide = ["halide-runtime"]
 serialize = ["serde", "euclid/serde"]

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    #[cfg(all(feature = "oiio", not(feature = "docs-rs")))]
+    #[cfg(all(feature = "oiio", not(feature = "docs-rs"), not(feature = "oiio-custom")))]
     {
         let mut pkg = std::process::Command::new("pkg-config");
         pkg.arg("--cflags")
@@ -44,5 +44,20 @@ fn main() {
                 println!("cargo:rustc-link-lib={lib}");
             }
         }
+    }
+
+    #[cfg(all(feature = "oiio-custom", not(feature = "docs-rs")))]
+    {
+        let oiio_include = env!("OIIO_CUSTOM_INCLUDE", "Must set OIIO_CUSTOM_INCLUDE env in .cargo/config.toml to directory with OpenImageIO headers");
+        let oiio_lib = env!("OIIO_CUSTOM_LIB", "Must set OIIO_CUSTOM_LIB env in .cargo/config.toml to directory with compiled OpenImageIO libraries");
+
+        let mut config = cpp_build::Config::new();
+        config.flag("-std=c++14").flag("-w");
+        config.include(oiio_include);
+        config.build("src/io/oiio.rs");
+
+        println!("cargo:rustc-link-search={}", oiio_lib);
+        println!("cargo:rustc-link-lib=OpenImageIO");
+        println!("cargo:rustc-link-lib=OpenImageIO_Util");
     }
 }


### PR DESCRIPTION
Allows setting a custom OpenImageIO location. This is useful if a custom OpenImageIO compilation needs to be used.

To do so set the `oiio-custom` feature flag in the project's Cargo.toml.

```
image2 = { features = ["oiio-custom", "parallel"] }
```

Then, in the project's `.cargo/config.toml`, set the `OIIO_CUSTOM_INCLUDE` and `OIIO_CUSTOM_LIB` env vars to point to the OpenImageIO headers and libraries.

```
[env]
OIIO_CUSTOM_INCLUDE = { value = "deps/oiio/dist/include/", relative = true }
OIIO_CUSTOM_LIB = { value = "deps/oiio/dist/lib", relative = true }
```